### PR TITLE
deps: bump nockchain to 09292f90f4d3 for Aletheia activation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ uuid = { version = "1.6.1", features = ["v4", "serde"] }
 bytes = { version = "1.10.1" }
 
 # nockchain
-nockchain-libp2p-io = { git = "https://github.com/swpsco/nockchain.git", rev = "5703d6839542f7976b8696541458a8f385b1793a", package = "nockchain-libp2p-io" }
-nockapp = { git = "https://github.com/swpsco/nockchain.git", rev = "5703d6839542f7976b8696541458a8f385b1793a", package = "nockapp" }
+nockchain-libp2p-io = { git = "https://github.com/swpsco/nockchain.git", rev = "980a0a1045e6adca027e9b5d3a909e56ffc12bc4", package = "nockchain-libp2p-io" }
+nockapp = { git = "https://github.com/swpsco/nockchain.git", rev = "980a0a1045e6adca027e9b5d3a909e56ffc12bc4", package = "nockapp" }


### PR DESCRIPTION
Pulls in the rebuilt assets/dumb.jam compiled from the post-Phase-2 hoon sources, plus the +find-min-timestamp finalization (checkpointed digests for heights 65,499 and 65,500). Required for nodes downstream of this pin to validate the canonical chain after the asert-phase boundary at block 65,500.